### PR TITLE
[Anime Format] Align Anime with EMBY Library style with batch mode

### DIFF
--- a/app/anime_format/anime_format.sh
+++ b/app/anime_format/anime_format.sh
@@ -1,6 +1,19 @@
 # !/bin/bash
 cur_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+# Some test cases to try: https://sed.js.org/
+#   Res/Mutable/Complete/Anime/aaa [tmdbid=128824]/S1
+#   Res/Mutable/Complete/Anime/aaa [tmdbid=128824]/S1/
+#   Res/Mutable/Complete/Anime/aaa [tmdbid=128824]/SS
+#   Res/Mutable/Complete/Anime/aaa [tmdbid=128824]/ S1
+#   Res/Mutable/Complete/Anime/aaa [tmdbid=128824]/S1+15
+#   Res/Mutable/Complete/Anime/aaa [tmdbid=128824]/S1:15/
+#   Res/Mutable/Complete/Anime/aaa [tmdbid=128824]/S1+15/
+#   Res/Mutable/Complete/Anime/aaa [tmdbid=128824]/S1-115/
+#   Res/Mutable/Complete/Anime/aaa [tmdbid=128824]/S1-33/fff
+#   Res/Mutable/Complete/Anime/aaa [tmdbid=128824]/S1-33+7/
+regex_season_offset_pattern=".*\/S\([0-9]\{1,2\}\)\([+-][0-9]\{1,3\}\)\?\/*\$"
+
 input_root=$1
 category_path=$3
 input_filename=$4
@@ -23,19 +36,30 @@ echo " [INFO] Show input_filename = $input_filename"
 FormatEpisode() {
   local episode_name=$1
   local season_num=$2
+  local episode_offset=$3
   # echo "\n[Format]episode = $episode_name\nseason = $season_num\n"
   if [[ $episode_name =~ .(mp4|mkv|rmvb|ass) ]]; then
-    # some_anime/S2/[]..[08]..mp4 -> some_anime/S2/[]..[S2E08]..mp4
     local format_episode_name=($(echo $episode_name | sed \
-                      -e "s/\[\([0-9]\{2\}\)\]/\[S${season_num}E\1\]/" \
-                      -e "s/\[\([0-9]\{2\}\)[vV][0-9]\]/\[S${season_num}E\1\]/" \
-                      -e "s/\[\([0-9]\{2\}\)\ END/\[S${season_num}E\1\]/" \
-                      -e "s/\ \([0-9]\{2\}\)\ /\[S${season_num}E\1\]/" \
-                      -e "s/\ \([0-9]\{2\}\)[vV][0-9]\ /\[S${season_num}E\1\]/" \
-                      -e "s/\ \([0-9]\{2\}\)\[/\[S${season_num}E\1\]/" \
-                      -e "s/\ \([0-9]\{2\}\)[vV][0-9]\[/\[S${season_num}E\1\]/" \
+                      -e "s/\[\([0-9]\{2\}\)\]/\[##@@\1##@@\]/" \
+                      -e "s/\[\([0-9]\{2\}\)[vV][0-9]\]/\[##@@\1##@@\]/" \
+                      -e "s/\ \([0-9]\{2\}\)\ /\[##@@\1##@@\]/" \
+                      -e "s/\ \([0-9]\{2\}\)[vV][0-9]\ /\[##@@\1##@@\]/" \
+                      -e "s/\ \([0-9]\{2\}\)\[/\[##@@\1##@@\]/" \
+                      -e "s/\ \([0-9]\{2\}\)[vV][0-9]\[/\[##@@\1##@@\]/" \
                       -e "s/.tc.ass/.zho.ass/" \
                       -e "s/.sc.ass/.chs.ass/"))
+    # echo "show format_episode_name as "$format_episode_name
+    # The usage of /patt/!d;s//repl/ is to delete lines not matching your pattern, and if they match, extract particular element from it.
+    # See https://stackoverflow.com/questions/6011661/regexp-sed-suppress-no-match-output
+    local episode_number=($(echo $format_episode_name | sed \
+	    -e "/.*##@@\(.*\)##@@.*/!d;s//\1/"))
+    # echo "show org_episode_number as "$episode_number
+    if [ -n "$episode_offset" ]; then
+      episode_number=$((10#$episode_number$episode_offset))
+    fi
+    # echo "show fixed_episode_number as "$episode_number
+    format_episode_name=($(echo $format_episode_name | sed \
+	    -e "s/##@@.*##@@/S${season_num}E$episode_number/"))
   fi
   echo "$format_episode_name"
 }
@@ -45,11 +69,13 @@ ProcessSingleEpisode() {
   local input_path=$2
   local output_path=$3
   local season_num=$4
+  local episode_offset=$5
 
   echo "  [INFO] Show processing season $season_num"
   echo "  [INFO] Show processing episode $input_path/$filename"
+  echo "  [INFO] Show processing episode offset as $episode_offset"
 
-  local format_episode_name="$(FormatEpisode $filename $season_num)"
+  local format_episode_name="$(FormatEpisode $filename $season_num $episode_offset)"
 
   echo "  [INFO] Show format filename = $format_episode_name"
 
@@ -68,12 +94,13 @@ ProcessSingleTask() {
   local filename=$2
   local output_path=$3
   local season_num=$4
+  local episode_offset=$5
   if [[ -d $input_path/$filename ]]; then
     for episode_filename in $(ls $input_path/$filename); do
-      ProcessSingleEpisode $episode_filename $input_path/$filename $output_path $season_num
+      ProcessSingleEpisode $episode_filename $input_path/$filename $output_path $season_num $episode_offset
     done
   elif [[ -f "$input_path/$filename" ]]; then
-    ProcessSingleEpisode $filename $input_path $output_path $season_num
+    ProcessSingleEpisode $filename $input_path $output_path $season_num $episode_offset
   else
     echo "  [ERROR] ProcessSingleTask error! $input_path/$filename is neither a path or a file"
   fi
@@ -83,22 +110,29 @@ org_ifs=$IFS
 IFS=$'\n'
 if [ -v $category_path ]; then
   for anime_name in $(ls $input_root); do
-    for season_num in $(ls $input_root/$anime_name); do
-      for episode_name in $(ls $input_root/$anime_name/$season_num); do
-        ProcessSingleTask $input_root/$anime_name/$season_num $episode_name $output_path/$anime_name/$season_num $season_num
+    for sub_dir in $(ls $input_root/$anime_name); do
+      season_num=$(echo /$sub_dir/ | sed -e "/$regex_season_offset_pattern/!d;s//\1/g")
+      episode_offset=$(echo /$sub_dir/ | sed -e "/$regex_season_offset_pattern/!d;s//\2/g")
+      for episode_name in $(ls $input_root/$anime_name/$sub_dir); do
+        ProcessSingleTask $input_root/$anime_name/$sub_dir $episode_name $output_path/$anime_name/S$season_num $season_num $episode_offset
       done
     done
   done
 else
   # Extract season info from path. Ex. some_anime/S2/ -> 2
-  season_num=$(echo $category_path | sed -e "s/.*\/S\([0-9]\+\)\/\?/\1/g")
+  # Category Path      | Season#  | Offset |
+  #  anime/S2          |  2       |        |
+  #  anime/S2+10       |  2       |  +10   |
+  season_num=$(echo $category_path | sed -e "/$regex_season_offset_pattern/!d;s//\1/g")
+  episode_offset=$(echo $category_path | sed -e "/$regex_season_offset_pattern/!d;s//\2/g")
   echo " [INFO] Show extract season_num = $season_num"
+  echo " [INFO] Show extract episode_offset = $episode_offset"
   if [ -v $input_filename ]; then
     for episode_name in $(ls $input_root/$category_path); do
-      ProcessSingleTask $input_root/$category_path $episode_name $output_path/$category_path $season_num
+      ProcessSingleTask $input_root/$category_path $episode_name $output_path/$category_path $season_num $episode_offset
     done 
   else
-    ProcessSingleTask $input_root/$category_path $input_filename $output_path/$category_path $season_num
+    ProcessSingleTask $input_root/$category_path $input_filename $output_path/$category_path $season_num $episode_offset
   fi
 fi
   

--- a/app/anime_format/batch_wrapper.sh
+++ b/app/anime_format/batch_wrapper.sh
@@ -1,0 +1,13 @@
+# !/bin/bash
+cur_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+log_suffix=`date '+%Y-%m-%d'`
+log_dir=$cur_dir"/log/"$client
+log_file=$log_dir"/batch_anime_"$log_suffix".log"
+err_file=$log_dir"/batch_anime_"$log_suffix".error.log"
+
+scan_path=$1
+output_path=$2
+
+echo "begin batch processing..." > $log_file
+
+bash anime_format.sh $1 $2 2>> $err_file 1>> $log_file


### PR DESCRIPTION
- Add a batch_wrapper call anime_format.sh, running in batch mode with arg specifying input dir and output dir. It'll scan the subdir automatically, expect the subdir to be the anime's name. Ex. 
  - input_dir/some anime [tmbdid=123123]/S1/xxx[S1E02]xxx.mp4
- Add a feature to enable adjust to episode number by offset set in the season part in the dir. Ex: 
  - input_dir/some anime [tmdbid=123123]/S1+25/xxx[E02]xxx.mp4 -> 
  - input_dir/some anime [tmdbid=123123]/S1/xxx[E27]xxx.mp4
  - This will be useful when the episode number the encoder published is different from tmdb metadata